### PR TITLE
when using takeSnapshot on apps that actively block this action, prov…

### DIFF
--- a/src/com/dtmilano/android/adb/adbclient.py
+++ b/src/com/dtmilano/android/adb/adbclient.py
@@ -640,7 +640,7 @@ class AdbClient:
         if not PIL_AVAILABLE:
             try:
                 global Image
-                from PIL import Image
+                import Image
                 PIL_AVAILABLE = True
             except:
                 raise Exception("You have to install PIL to use takeSnapshot()")


### PR DESCRIPTION
…ide proper python exception instead of crashing the process

In situations where app has screenshot protection, the viewclient takeSnapshot call crashes taking the whole process down.
putting try/except around takeSnapshot does not help.

For strange reason, the solution is to simply replace "from PIL import Image" with "import Image"